### PR TITLE
Fixes for uv in plum

### DIFF
--- a/header-panel.less
+++ b/header-panel.less
@@ -4,11 +4,9 @@
     .headerPanel{
         .options{
             .centerOptions{
-                width: 390px;
             }
             .rightOptions{
                 .settings{
-                    //background: url('@{theme-img-path}hamburger.png');
                 }
             }
         }

--- a/styles.less
+++ b/styles.less
@@ -1,0 +1,13 @@
+
+#app{
+    .headerPanel{
+        .centerOptions{
+            .image-selectionbox-options{
+                float: left;
+                margin: 0 0 0 0;
+                padding-top: 7px;
+                padding-left: 10px;
+            }
+        }
+    }
+}

--- a/theme.less
+++ b/theme.less
@@ -1,3 +1,4 @@
 @import 'variables';
 @import 'header-panel';
 @import 'footer-panel';
+@import 'styles';


### PR DESCRIPTION
Fixes for the universal viewer in plum. Aligns the drop down with other elements and handles longer image names gracefully.
